### PR TITLE
Add support for time-to-live (TTL)

### DIFF
--- a/squid-algorithm/src/hashtable.rs
+++ b/squid-algorithm/src/hashtable.rs
@@ -15,11 +15,10 @@ impl MapAlgorithm {
     where
         T: ToString,
     {
-        if let Some(counter) = self.data.get_mut(&key.to_string()) {
-            *counter += 1;
-        } else {
-            self.data.insert(key.to_string(), 1);
-        }
+        self.data
+            .entry(key.to_string())
+            .and_modify(|d| *d += 1)
+            .or_insert(1);
     }
 
     /// Classify the most frequently used words.


### PR DESCRIPTION
This PR aims to add a support for time-to-live (TTL) on Squid. This means that
entries (sentences) can expire after a certain time (expressed in seconds). This
can reduce storage, but increase RAM usage (due to the indexes required).
This PR also refound the stockage system. From now, everything is not stocked
in ONE file, but splitted into multiple files. This should improve scalability.